### PR TITLE
Make the children navigation button more consistent with Wagtail UI.

### DIFF
--- a/client/src/components/explorer/ExplorerItem.js
+++ b/client/src/components/explorer/ExplorerItem.js
@@ -28,7 +28,7 @@ const ExplorerItem = ({ title, typeName, data, filter, onItemClick }) => {
           className="c-explorer__children"
           onClick={onItemClick.bind(null, id)}
         >
-          <Icon name="folder-inverse" title={STRINGS.SEE_CHILDREN} />
+          <Icon name="arrow-right" title={STRINGS.SEE_CHILDREN} />
         </span>
       ) : null}
 

--- a/client/src/components/explorer/style.scss
+++ b/client/src/components/explorer/style.scss
@@ -126,6 +126,7 @@ $c-explorer-easing: cubic-bezier(0.075, 0.820, 0.165, 1.000);
 
 .c-explorer__item {
     display: block;
+    position: relative;
 
     &:hover {
         background: rgba(0, 0, 0, 0.25);
@@ -146,13 +147,18 @@ $c-explorer-easing: cubic-bezier(0.075, 0.820, 0.165, 1.000);
 
 .c-explorer__children {
     display: inline-block;
-    border-radius: 50rem;
-    border: solid 1px #aaa;
     color: $color-white;
     line-height: 1;
-    padding: .5em .3em .5em .5em;
+    padding: .7em .3em .7em .7em;
     float: right;
     cursor: pointer;
+    display: inline-block;
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    font-size: 2em;
+
 
     &:hover {
         background: rgba(0,0,0,0.5);


### PR DESCRIPTION
This change makes the navigation to the children of an item more consistent with the rest of the Wagtail UI.

Preview:
![screenshot 2017-02-10 13 31 29](https://cloud.githubusercontent.com/assets/143557/22828515/977ba05c-ef95-11e6-97b6-113d9f279647.png)

Hover:
![screenshot 2017-02-10 13 31 25](https://cloud.githubusercontent.com/assets/143557/22828517/99c3dc44-ef95-11e6-8778-03dd45622fa3.png)
